### PR TITLE
Enhance task management by adding origins to tasks

### DIFF
--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -7,6 +7,7 @@ import { useDraggable } from "@dnd-kit/core";
 import { DatePicker } from "./DatePicker";
 import { format, parseISO } from "date-fns";
 import usePlanner from "../state/planner";
+import { TaskOrigin } from "@/features/tasks/selectors";
 
 type TaskRowProps = {
   task: Task;
@@ -15,6 +16,7 @@ type TaskRowProps = {
   onToggleFocus?: (id: string) => void;
   interactive?: boolean;
   onContextMenu?: (e: React.MouseEvent) => void;
+  origins?: TaskOrigin[];
 };
 
 const TaskRow = React.forwardRef<HTMLDivElement, TaskRowProps>(
@@ -26,6 +28,7 @@ const TaskRow = React.forwardRef<HTMLDivElement, TaskRowProps>(
       onToggleFocus,
       interactive = true,
       onContextMenu,
+      origins,
       ...props
     },
     ref
@@ -76,6 +79,11 @@ const TaskRow = React.forwardRef<HTMLDivElement, TaskRowProps>(
           }`}
         >
           {task.title}
+        </div>
+        <div className="flex items-center gap-1">
+          {origins?.map((origin) => (
+            <Chip key={origin} label={origin} />
+          ))}
         </div>
         {task.est_minutes > 0 && (
           <span className="text-[11px] text-zinc-400 border border-white/10 rounded-md px-1.5 py-0.5">

--- a/src/components/dashboard/RightColumn.tsx
+++ b/src/components/dashboard/RightColumn.tsx
@@ -9,7 +9,7 @@ export function RightColumn() {
     <div className="p-6 flex flex-col gap-6 h-full relative min-w-0">
       <Header />
       <div className="grid grid-cols-[1fr_auto] gap-6 flex-1 min-h-0">
-        <TodosPane />
+        <TodosPane dateISO={todayISO()} />
         <MiniDayRail />
       </div>
       <BacklogBelt dateISO={todayISO()} />

--- a/src/components/dashboard/TodosPane.tsx
+++ b/src/components/dashboard/TodosPane.tsx
@@ -1,27 +1,17 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import usePlanner from "@/state/planner";
 import TaskRow from '@/components/TaskRow';
 import { CompactAdd } from '@/components/CompactAdd';
+import { useTodayTasks } from '@/features/tasks/selectors';
 
-export function TodosPane() {
-    const tasks = usePlanner(s => s.tasks);
-    const blocks = usePlanner(s => s.blocks);
+export function TodosPane({ dateISO }: { dateISO: string }) {
     const focusQueue = usePlanner(s => s.focusQueue);
     const activeFocus = usePlanner(s => s.activeFocus);
     const toggleFocus = usePlanner(s => s.toggleFocus);
     const toggleTask = usePlanner(s => s.toggleTask);
     const addTask = usePlanner(s => s.addTask);
+    const todayTasks = useTodayTasks(dateISO);
     
-    const scheduledTaskIds = useMemo(() => {
-        return new Set(blocks.flatMap(b => {
-            if (b.kind === 'atomic' && b.taskId) return [b.taskId];
-            if (b.kind === 'work' && b.items) return b.items.map(item => item.taskId);
-            return [];
-        }));
-    }, [blocks]);
-
-    const todayTasks = tasks.filter(t => !t.done && scheduledTaskIds.has(t.id));
-
     const inQueue = useCallback((id: string) => {
         return focusQueue.includes(id) || activeFocus.includes(id);
     }, [focusQueue, activeFocus]);
@@ -38,11 +28,12 @@ export function TodosPane() {
                             onToggle={() => toggleTask(task.id)}
                             inQueue={inQueue}
                             onToggleFocus={() => toggleFocus(task.id)}
+                            origins={task.origins}
                         />
                     ))
                 ) : (
                     <div className="text-sm text-zinc-500 italic p-2">
-                        No tasks scheduled for today. Drag tasks from your backlog or add new ones.
+                        Pin, set due, or schedule tasks to see them here.
                     </div>
                 )}
             </div>


### PR DESCRIPTION
- Update TaskRow component to display task origins.
- Modify TodosPane to pass task origins to TaskRow.
- Refactor selectors to return tasks with their origins for better context.
- Rename selectTodayTaskIds to selectTodayTasks for clarity and improved functionality.